### PR TITLE
Adjustments for Hypothesis duplicates

### DIFF
--- a/app/controllers/citations_controller.rb
+++ b/app/controllers/citations_controller.rb
@@ -12,7 +12,7 @@ class CitationsController < ApplicationController
   def show
     slug = [params[:publication_id], params[:id]].reject(&:blank?).join("-")
     @citation = Citation.friendly_find!(slug)
-    @hypotheses = @citation.hypotheses
+    @hypotheses = @citation.hypotheses.reorder(created_at: :desc)
   end
 
   private

--- a/app/javascript/stylesheets/utils/_table_list.scss
+++ b/app/javascript/stylesheets/utils/_table_list.scss
@@ -15,6 +15,10 @@
   }
   tr td:last-child {
     width: 85%; // This is effectively min-width for table cells, which means that the definition max-width is 15%
+    ul {
+      padding-left: 1.5em;
+      margin-bottom: 0;
+    }
   }
   tr.active-row {
     background-color: #ebf5fb !important;

--- a/app/models/hypothesis.rb
+++ b/app/models/hypothesis.rb
@@ -9,7 +9,7 @@ class Hypothesis < ApplicationRecord
   has_many :hypothesis_citations, autosave: true, dependent: :destroy
   has_many :citations, through: :hypothesis_citations
   has_many :publications, through: :citations
-  has_many :hypothesis_tags
+  has_many :hypothesis_tags, dependent: :destroy
   has_many :tags, through: :hypothesis_tags
   has_many :hypothesis_quotes, -> { score_ordered }
   has_many :quotes, through: :hypothesis_quotes

--- a/app/models/hypothesis_citation.rb
+++ b/app/models/hypothesis_citation.rb
@@ -56,6 +56,7 @@ class HypothesisCitation < ApplicationRecord
   def update_hypothesis
     # Ensure we don't call this in a loop, or during creation
     return false if skip_associated_tasks || (hypothesis.present? && hypothesis.created_at > Time.current - 5.seconds)
-    hypothesis&.update(updated_at: Time.current)
+    # Only update the hypothesis if it isn't destroyed
+    hypothesis&.update(updated_at: Time.current) if !hypothesis.destroyed?
   end
 end

--- a/app/models/hypothesis_citation.rb
+++ b/app/models/hypothesis_citation.rb
@@ -15,6 +15,13 @@ class HypothesisCitation < ApplicationRecord
 
   attr_accessor :skip_associated_tasks
 
+  # I've been running into this issue for a little while, so adding this method
+  # BUT! I think once the data is fixed and update_flat_file_database_without_import is run, it won't be a problem anymore
+  def duplicated
+    HypothesisCitation.where(citation_id: citation_id, hypothesis_id: hypothesis_id)
+      .where.not(id: id)
+  end
+
   def quotes_text_array
     return [] unless quotes_text.present?
     quotes_text.split(/\n/).reject(&:blank?).map { |t| Quote.normalize(t) }

--- a/app/models/hypothesis_citation.rb
+++ b/app/models/hypothesis_citation.rb
@@ -15,8 +15,8 @@ class HypothesisCitation < ApplicationRecord
 
   attr_accessor :skip_associated_tasks
 
-  # I've been running into this issue for a little while, so adding this method
-  # BUT! I think once the data is fixed and update_flat_file_database_without_import is run, it won't be a problem anymore
+  # There were some issues with legacy hypothesis_citations having duplicates
+  # leaving method around until certain they're resolved
   def duplicates
     HypothesisCitation.where(citation_id: citation_id, hypothesis_id: hypothesis_id)
       .where.not(id: id)

--- a/app/models/hypothesis_citation.rb
+++ b/app/models/hypothesis_citation.rb
@@ -17,7 +17,7 @@ class HypothesisCitation < ApplicationRecord
 
   # I've been running into this issue for a little while, so adding this method
   # BUT! I think once the data is fixed and update_flat_file_database_without_import is run, it won't be a problem anymore
-  def duplicated
+  def duplicates
     HypothesisCitation.where(citation_id: citation_id, hypothesis_id: hypothesis_id)
       .where.not(id: id)
   end

--- a/app/views/citations/_display.html.haml
+++ b/app/views/citations/_display.html.haml
@@ -1,4 +1,5 @@
 - render_waiting_for_approval ||= false
+- hypothesis_citation_id ||= nil
 
 .col-md-6
 
@@ -17,7 +18,7 @@
   %table.table-list
     %tbody
       %tr
-        %td Citation URL
+        %td URL
         %td
           - if citation.url.present?
             = link_to citation.url, citation.url
@@ -41,6 +42,11 @@
         %tr.only-dev-visible
           %td ID
           %td= citation.id
+        - if hypothesis_citation_id.present?
+          %tr.only-dev-visible
+            %td
+              %small Hypothesis Citation ID
+            %td= hypothesis_citation_id
       %tr
         %td URL direct link?
         %td= display_true_or_false(citation.url_is_direct_link_to_full_text)

--- a/app/views/citations/_display.html.haml
+++ b/app/views/citations/_display.html.haml
@@ -3,7 +3,7 @@
 
 .col-md-6
 
-  - if render_waiting_for_approval && citation.unapproved?
+  - if render_waiting_for_approval && citation.waiting_on_github?
     .alert.alert-info
       - if citation.pull_request_number.present?
         %h4
@@ -11,24 +11,24 @@
           = link_to "PR#{citation.pull_request_number}", citation.pull_request_url
       - else
         Waiting for pull request to be created, page will reload.
-        -# NOTE: This will reload endlessly, which may not be what we want
-        :javascript
-          window.setTimeout(() => {location.reload();}, 1000);
+        -# if citation hasn't been updated recently, skip this (something broke?)
+        - if @citation.updated_at > Time.current - 2.minutes
+          :javascript
+            window.setTimeout(() => {location.reload();}, 1000);
 
   %table.table-list
     %tbody
-      %tr
-        %td URL
-        %td
-          - if citation.url.present?
-            = link_to citation.url, citation.url
       %tr
         %td Title
         %td
           = citation.title
           - unless controller_name == "citations" && action_name == "show"
             = link_to internal_link_text, citation_path(citation.to_param), class: "internal-link"
-
+      %tr
+        %td URL
+        %td
+          - if citation.url.present?
+            = link_to citation.url, citation.url
       - if citation.approved?
         %tr
           %td GitHub

--- a/app/views/citations/_table.html.haml
+++ b/app/views/citations/_table.html.haml
@@ -3,6 +3,9 @@
 .full-screen-table
   %table.table.table-striped.table-sm.table-bordered
     %thead
+      - if display_dev_info?
+        %th.only-dev-visible.small
+          ID
       %th
         Title
       %th
@@ -16,6 +19,9 @@
     %tbody
       - citations.each do |citation|
         %tr
+          - if display_dev_info?
+            %td.only-dev-visible.small
+              = citation.id
           %td
             = citation.title
             = link_to internal_link_text, citation_path(citation.to_param), class: "internal-link"

--- a/app/views/citations/show.html.haml
+++ b/app/views/citations/show.html.haml
@@ -6,4 +6,4 @@
 
 %h2.mt-4.mb-1 Hypotheses
 
-= render partial: "/hypotheses/table", locals: { citations: @hypotheses }
+= render partial: "/hypotheses/table", locals: { hypotheses: @hypotheses }

--- a/app/views/hypotheses/_table.html.haml
+++ b/app/views/hypotheses/_table.html.haml
@@ -34,13 +34,18 @@
               = link_to tag.title, hypotheses_path(sortable_search_params.merge(search_array: (search_tags + [tag.title]))), class: "tag-bubble small"
 
           %td.d-none.d-md-table-cell
-            - citation = hypothesis.citations.each do |citation|
-              - next if citation.id == skip_citation_id
-              .d-block.small
-                - if citation.publication.present? && !citation.publication.title_url?
-                  #{citation.publication.title}:
-                %em
-                  = citation.title.truncate(75)
+            %ul
+              - hypothesis.hypothesis_citations.each do |hypothesis_citation|
+                - next if hypothesis_citation.citation_id == skip_citation_id
+                - citation = hypothesis_citation.citation
+                %li.small
+                  - if citation.publication.present? && !citation.publication.title_url?
+                    #{citation.publication.title}:
+                  %em
+                    = citation.title.truncate(75)
+                  %small.less-strong
+                    #{hypothesis_citation.quotes.count}
+                    = "quote".pluralize(hypothesis_citation.quotes.count)
 
           %td.d-none.d-md-table-cell
             %small.convertTime

--- a/app/views/hypotheses/_table.html.haml
+++ b/app/views/hypotheses/_table.html.haml
@@ -6,16 +6,22 @@
 .full-screen-table
   %table.table.table-striped.table-sm.table-bordered
     %thead
+      - if display_dev_info?
+        %th.only-dev-visible.small
+          ID
       %th
         Hypothesis
       %th.d-none.d-md-table-cell
-        Citation
+        Citations
       %th.d-none.d-md-table-cell
         Created
     %tbody
       - search_tags = @search_tags || []
       - hypotheses.each do |hypothesis|
         %tr
+          - if display_dev_info?
+            %td.only-dev-visible.small
+              = hypothesis.id
           %td
             = hypothesis.title
             .score-bubble.small{ class: hypothesis_score_class(hypothesis.score) }

--- a/app/views/hypotheses/index.html.haml
+++ b/app/views/hypotheses/index.html.haml
@@ -19,4 +19,7 @@
     = paginate @hypotheses
   .mt-4
 
-= render partial: "/hypotheses/list", locals: { hypotheses: @hypotheses }
+- if ParamsNormalizer.boolean(params[:render_table])
+  = render partial: "/hypotheses/table", locals: { hypotheses: @hypotheses }
+- else
+  = render partial: "/hypotheses/list", locals: { hypotheses: @hypotheses }

--- a/app/views/hypotheses/show.html.haml
+++ b/app/views/hypotheses/show.html.haml
@@ -87,9 +87,6 @@
                   Approved by
                   = link_to "PR#{@hypothesis.pull_request_number}", @hypothesis.pull_request_url
         %tr
-          %td Direct quotation?
-          %td= display_true_or_false(@hypothesis.has_direct_quotation)
-        %tr
           %td Topics
           %td
             - if @hypothesis.tags.any?
@@ -130,5 +127,5 @@
   = "Citation".pluralize(@hypothesis.citations.count)
 
 .row.mt-2
-  - @citations.each do |citation|
-    = render partial: "/citations/display", locals: { citation: citation }
+  - @hypothesis.hypothesis_citations.each do |hypothesis_citation|
+    = render partial: "/citations/display", locals: { citation: hypothesis_citation.citation, hypothesis_citation_id: hypothesis_citation.id }


### PR DESCRIPTION
Because `url` was added to `HypothesisCitation` after many were created, importing the content files from GitHub created duplicates.

Snippets used to diagnose issues and fix this:

```ruby
hc_duplicated_ids = HypothesisCitation.all.select { |hc| hc.duplicates.any? }.map(&:id)
hc_higher_ids = HypothesisCitation.all.select { |hc| hc.duplicates.where("id < ?", hc.id).any? }.map(&:id)
hc_quote_ids = HypothesisCitation.all.select { |hc| hc.hypothesis_quotes.any? }.map(&:id)
hc_quote_ids & hc_higher_ids # Shouldn't have anything, because we don't want to lose quotes data from the deletion
hc_higher_ids.each { |i| HypothesisCitation.find(i).destroy }

HypothesisCitation.all.each { |hc| hc.update(url: hc.citation.url) if hc.url.blank? }
```