### PR TITLE
switch authors to jsonb, to enable comparison

### DIFF
--- a/db/migrate/20210831200424_migrate_authors_to_jsonb.rb
+++ b/db/migrate/20210831200424_migrate_authors_to_jsonb.rb
@@ -1,0 +1,6 @@
+class MigrateAuthorsToJsonb < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :citations, :authors, :authors_old
+    add_column :citations, :authors, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_27_224235) do
+ActiveRecord::Schema.define(version: 2021_08_31_200424) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 2021_08_27_224235) do
     t.bigint "publication_id"
     t.text "title"
     t.text "slug"
-    t.json "authors"
+    t.json "authors_old"
     t.datetime "published_at"
     t.integer "kind"
     t.text "url"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2021_08_27_224235) do
     t.integer "score"
     t.boolean "submitting_to_github", default: false
     t.text "doi"
+    t.jsonb "authors"
     t.index ["creator_id"], name: "index_citations_on_creator_id"
     t.index ["publication_id"], name: "index_citations_on_publication_id"
   end

--- a/spec/models/argument_spec.rb
+++ b/spec/models/argument_spec.rb
@@ -318,22 +318,4 @@ RSpec.describe Argument, type: :model do
       end
     end
   end
-
-  describe "citations_not_removed" do
-    let(:argument) { FactoryBot.create(:argument) }
-    let(:argument_quote1) { FactoryBot.create(:argument_quote, argument: argument, ref_number: 2) }
-    let(:argument_quote2) { FactoryBot.create(:argument_quote, argument: argument, ref_number: 3, removed: true) }
-    let!(:argument_quote3) { FactoryBot.create(:argument_quote, argument: argument, ref_number: 4, url: argument_quote1.url) }
-    let(:argument_quote4) { FactoryBot.create(:argument_quote, argument: argument, ref_number: 1) }
-    let!(:citation1) { argument_quote1.citation }
-    let!(:citation2) { argument_quote2.citation }
-    let!(:citation3) { argument_quote4.citation }
-    let(:target_argument_quote_ids) { [argument_quote4.id, argument_quote1.id, argument_quote2.id, argument_quote3.id] }
-    it "only includes the not-removed" do
-      expect(argument.reload.argument_quotes.ref_ordered.pluck(:id)).to eq target_argument_quote_ids
-      # TODO: can't get the ordering to work. Ideally these associations would be ref_ordered, skipping for now
-      expect(argument.citations.pluck(:id)).to match_array([citation3.id, citation1.id, citation2.id])
-      expect(argument.citations_not_removed.pluck(:id)).to match_array([citation3.id, citation1.id])
-    end
-  end
 end

--- a/spec/models/argument_spec.rb
+++ b/spec/models/argument_spec.rb
@@ -318,4 +318,22 @@ RSpec.describe Argument, type: :model do
       end
     end
   end
+
+  describe "citations_not_removed" do
+    let(:argument) { FactoryBot.create(:argument) }
+    let(:argument_quote1) { FactoryBot.create(:argument_quote, argument: argument, ref_number: 2) }
+    let(:argument_quote2) { FactoryBot.create(:argument_quote, argument: argument, ref_number: 3, removed: true) }
+    let!(:argument_quote3) { FactoryBot.create(:argument_quote, argument: argument, ref_number: 4, url: argument_quote1.url) }
+    let(:argument_quote4) { FactoryBot.create(:argument_quote, argument: argument, ref_number: 1) }
+    let!(:citation1) { argument_quote1.citation }
+    let!(:citation2) { argument_quote2.citation }
+    let!(:citation3) { argument_quote4.citation }
+    let(:target_argument_quote_ids) { [argument_quote4.id, argument_quote1.id, argument_quote2.id, argument_quote3.id] }
+    it "only includes the not-removed" do
+      expect(argument.reload.argument_quotes.ref_ordered.pluck(:id)).to eq target_argument_quote_ids
+      # TODO: can't get the ordering to work. Ideally these associations would be ref_ordered, skipping for now
+      expect(argument.citations.pluck(:id)).to match_array([citation3.id, citation1.id, citation2.id])
+      expect(argument.citations_not_removed.pluck(:id)).to match_array([citation3.id, citation1.id])
+    end
+  end
 end


### PR DESCRIPTION
Required by #134

Run to process the migration:

```ruby
Citation.all.each { |c| c.update_column :authors, c.authors_old }
```